### PR TITLE
add mailto tag

### DIFF
--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -44,7 +44,7 @@ Sander Smeenk
 * SSH Key: [freshdot.net/s/ssmeenk.ssh.pub](https://www.freshdot.net/s/ssmeenk.ssh.pub)
 
 Teun Vink
-* Email: [nlnog@teun.tv](nlnog@teun.tv)
+* Email: [nlnog@teun.tv](mailto:nlnog@teun.tv)
 * Affiliation: NLNOG Board / BIT
 * PGP Key: [https://teun.tv/nlnog.asc](https://teun.tv/nlnog.asc)
 * SSH key: [https://teun.tv/nlnog.pub](https://teun.tv/nlnog.pub)


### PR DESCRIPTION
`mailto:` was missing for Teun's mailaddress, rendering it into a 404 error